### PR TITLE
Allow accepting invalid images after 3 attempts

### DIFF
--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
@@ -40,6 +40,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import kotlin.NotImplementedError;
+
 import static org.rdtoolkit.interop.InterfacesKt.captureReturnIntent;
 import static org.rdtoolkit.support.interop.RdtIntentBuilder.INTENT_EXTRA_RDT_SESSION_ID;
 import static org.rdtoolkit.support.interop.RdtIntentBuilder.INTENT_EXTRA_RESPONSE_TRANSLATOR;
@@ -125,6 +127,14 @@ public class CaptureActivity extends AppCompatActivity implements ComponentEvent
             }
         });
 
+        captureViewModel.getPermitCaptureOverride().observe(this, value -> {
+            if (value) {
+                findViewById(R.id.capture_timer_button_accept_error_image).setVisibility(View.VISIBLE);
+            } else {
+                findViewById(R.id.capture_timer_button_accept_error_image).setVisibility(View.GONE);
+            }
+        });
+
 
         captureViewModel.getProcessingState().observe(this, value -> {
             switch (value) {
@@ -137,6 +147,7 @@ public class CaptureActivity extends AppCompatActivity implements ComponentEvent
                     }
                     break;
                 case COMPLETE:
+                case SKIPPED:
                     resultsTab.setEnabled(true);
                     if(navController.getCurrentDestination().getId() != R.id.capture_results) {
                         if (navController.getCurrentDestination().getId() == R.id.capture_timer) {
@@ -147,6 +158,8 @@ public class CaptureActivity extends AppCompatActivity implements ComponentEvent
                         }
                     }
                     break;
+                default:
+                    throw new NotImplementedError("Unimplemented Capture processing state");
             }
         });
 
@@ -269,6 +282,10 @@ public class CaptureActivity extends AppCompatActivity implements ComponentEvent
 
     public void recordResults(View v) {
         captureViewModel.commitResult();
+    }
+
+    public void overrideCaptureError(View v) {
+        captureViewModel.setProcessingSkipped();
     }
 
     public void overrideExpiration(View v) {

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureTimerFragment.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureTimerFragment.java
@@ -22,6 +22,8 @@ import net.vrgsoft.arcprogress.ArcProgressBar;
 import org.rdtoolkit.R;
 import org.rdtoolkit.support.model.session.TestReadableState;
 
+import kotlin.NotImplementedError;
+
 import static android.view.View.GONE;
 import static android.view.View.VISIBLE;
 import static org.rdtoolkit.util.MediaUtilKt.setImageBitmapFromFile;
@@ -56,12 +58,15 @@ public class CaptureTimerFragment extends Fragment {
             switch (value) {
                 case PRE_CAPTURE:
                 case COMPLETE:
+                case SKIPPED:
                 case ERROR:
                     processingOverlay.setVisibility(View.INVISIBLE);
                     break;
                 case PROCESSING:
                     processingOverlay.setVisibility(View.VISIBLE);
                     break;
+                default:
+                    throw new NotImplementedError("Unimplemented capture processing state");
             }
         });
 

--- a/app/src/main/res/layout/fragment_capture_timer.xml
+++ b/app/src/main/res/layout/fragment_capture_timer.xml
@@ -88,6 +88,7 @@
         android:gravity="center_horizontal"
         android:visibility="invisible"
         android:layout_margin="16dp">
+
         <FrameLayout
             android:layout_gravity="center"
             android:paddingBottom="8dp"
@@ -105,6 +106,15 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
         </FrameLayout>
+
+        <Button
+            android:id="@+id/capture_timer_button_accept_error_image"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="overrideCaptureError"
+            android:visibility="gone"
+            style="@style/Button"
+            android:text="@string/capture_timer_accept_error_image" />
 
         <TextView
             android:id="@+id/capture_timer_process_status"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,4 +75,5 @@
     <string name="capture_summary_status_timer">Timer</string>
     <string name="capture_summary_status_timer_valid">Valid</string>
     <string name="capture_summary_status_timer_expired">Expired</string>
+    <string name="capture_timer_accept_error_image">Accept Image</string>
 </resources>


### PR DESCRIPTION
Allows users to "Accept" an image which couldn't be processed by a classifier library after 3 attempts at image capture, so that users are not permanently blocked if their camera or lighting conditions cannot capture an adequate image

![image](https://user-images.githubusercontent.com/155066/100478053-0cb16480-30b8-11eb-8de3-9e2b71a43480.png)
