### PR TITLE
Allow results to be read early

### DIFF
--- a/app/src/main/java/org/rdtoolkit/model/session/AppRepository.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/AppRepository.kt
@@ -13,6 +13,14 @@ class AppRepository(private val context : Context) {
         prefs().edit().putBoolean(PREFERENCE_ACKNOWLEDGED_DISCLAIMER, acknowledged).apply()
     }
 
+    fun hasAcknowledgedEarlyTimerDisclaimer() : Boolean {
+        return prefs().getBoolean(PREFERENCE_EARLY_TIMER_DISCLAIMER, false)
+    }
+
+    fun setAcknowledgedEarlyTimerDisclaimer(acknowledged : Boolean) {
+        prefs().edit().putBoolean(PREFERENCE_EARLY_TIMER_DISCLAIMER, acknowledged).apply()
+    }
+
     private fun prefs(): SharedPreferences {
         return context.getSharedPreferences(context.getString(R.string.default_preference_key)
                 , Context.MODE_PRIVATE)!!
@@ -20,5 +28,6 @@ class AppRepository(private val context : Context) {
 
     companion object {
         const val PREFERENCE_ACKNOWLEDGED_DISCLAIMER = "user_acknwoledged_disclaimer"
+        const val PREFERENCE_EARLY_TIMER_DISCLAIMER = "user_acknowleged_early_timer"
     }
 }

--- a/app/src/main/java/org/rdtoolkit/model/session/AppRepository.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/AppRepository.kt
@@ -21,6 +21,13 @@ class AppRepository(private val context : Context) {
         prefs().edit().putBoolean(PREFERENCE_EARLY_TIMER_DISCLAIMER, acknowledged).apply()
     }
 
+    fun clearDisclaimers() {
+        var editor = prefs().edit()
+        editor.remove(PREFERENCE_ACKNOWLEDGED_DISCLAIMER)
+        editor.remove(PREFERENCE_EARLY_TIMER_DISCLAIMER)
+        editor.commit()
+    }
+
     private fun prefs(): SharedPreferences {
         return context.getSharedPreferences(context.getString(R.string.default_preference_key)
                 , Context.MODE_PRIVATE)!!
@@ -29,5 +36,7 @@ class AppRepository(private val context : Context) {
     companion object {
         const val PREFERENCE_ACKNOWLEDGED_DISCLAIMER = "user_acknwoledged_disclaimer"
         const val PREFERENCE_EARLY_TIMER_DISCLAIMER = "user_acknowleged_early_timer"
+
+
     }
 }

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
@@ -298,6 +298,10 @@ public class CaptureActivity extends LocaleAwareCompatActivity implements Compon
         Navigation.findNavController(this, R.id.nav_host_fragment).navigate(R.id.capture_trigger_work_check);
     }
 
+    public void skipTimer(View v) {
+        captureViewModel.forceTestReadable();
+    }
+
     public void confirmRecordResults(View v) {
         captureViewModel.commitResult();
     }
@@ -307,7 +311,7 @@ public class CaptureActivity extends LocaleAwareCompatActivity implements Compon
     }
 
     public void overrideExpiration(View v) {
-        captureViewModel.setExpirationOverriden();
+        captureViewModel.forceTestReadable();
         Navigation.findNavController(this, R.id.nav_host_fragment).navigate(R.id.capture_start_fresh);
     }
 

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureTimerFragment.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureTimerFragment.java
@@ -8,6 +8,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -106,6 +108,17 @@ public class CaptureTimerFragment extends Fragment {
             ((TextView)view.findViewById(R.id.capture_timer_expiring_countdown)).setText(
                     String.format(getString(R.string.capture_timer_expiring_countdown_msg),
                             formattedTime));
+        });
+
+        CheckBox earlyDisclaimer = view.findViewById(R.id.capture_timer_cbx_early_disclaimer);
+        earlyDisclaimer.setOnCheckedChangeListener((compoundButton, b) -> mViewModel.setTimerDisclaimerAcknowledged(b));
+
+        mViewModel.getTimerSkipDisclaimerAvailable().observe(getViewLifecycleOwner(), value -> {
+            earlyDisclaimer.setVisibility(value ? VISIBLE : GONE);
+        });
+
+        mViewModel.getTimerSkipAvailable().observe(getViewLifecycleOwner(), value -> {
+            view.findViewById(R.id.capture_btn_skip_timer).setVisibility(value ? VISIBLE : GONE);
         });
 
         mViewModel.getTestState().observe(getViewLifecycleOwner(), value -> {

--- a/app/src/main/java/org/rdtoolkit/ui/preferences/ToolkitPreferencesFragment.java
+++ b/app/src/main/java/org/rdtoolkit/ui/preferences/ToolkitPreferencesFragment.java
@@ -23,6 +23,7 @@ import com.zeugmasolutions.localehelper.LocaleAwareCompatActivity;
 import com.zeugmasolutions.localehelper.LocaleHelper;
 
 import org.rdtoolkit.R;
+import org.rdtoolkit.model.session.AppRepository;
 
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -32,6 +33,7 @@ public class ToolkitPreferencesFragment extends PreferenceFragmentCompat impleme
 
     static final String LANG_CODE_SYSTEM_DEFAULT = "system_default";
     static final String PREFERENCE_KEY_LANGUAGE = "language";
+    static final String PREFERENCE_KEY_RESET_DISCLAIMERS = "reset_disclaimers";
     static final String TAG = ToolkitPreferencesFragment.class.getName();
 
     LinkedHashMap<String, Locale> locales;
@@ -42,10 +44,15 @@ public class ToolkitPreferencesFragment extends PreferenceFragmentCompat impleme
         locales = getTranslatedLocales();
 
         addLanguagePreference();
+        findPreference(PREFERENCE_KEY_RESET_DISCLAIMERS).setOnPreferenceClickListener(it -> {
+            new AppRepository(this.getContext()).clearDisclaimers();
+            it.setEnabled(false);
+            return true;
+        });
     }
 
     private void addLanguagePreference() {
-        final ListPreference listPreference = (ListPreference) findPreference(PREFERENCE_KEY_LANGUAGE);
+        final ListPreference listPreference = findPreference(PREFERENCE_KEY_LANGUAGE);
 
         Pair<CharSequence[], CharSequence[]> values = getSettingsPreferenceValues();
 

--- a/app/src/main/java/org/rdtoolkit/ui/sessions/TestSessionsAdapter.kt
+++ b/app/src/main/java/org/rdtoolkit/ui/sessions/TestSessionsAdapter.kt
@@ -87,7 +87,7 @@ class TestSessionsAdapter(private val sessionsViewModel : SessionsViewModel
         var captureButton = holder.view.findViewById<TextView>(R.id.sessions_card_button_capture)
 
         captureButton.tag = session.sessionId
-        if (session.state == STATUS.RUNNING && (session.getTestReadableState() == TestReadableState.READABLE || session.getTestReadableState() == TestReadableState.RESOLVING))x {
+        if (session.state == STATUS.RUNNING && (session.getTestReadableState() == TestReadableState.READABLE || session.getTestReadableState() == TestReadableState.RESOLVING)) {
             captureButton.visibility = View.VISIBLE
         } else {
             captureButton.visibility = View.GONE

--- a/app/src/main/java/org/rdtoolkit/ui/sessions/TestSessionsAdapter.kt
+++ b/app/src/main/java/org/rdtoolkit/ui/sessions/TestSessionsAdapter.kt
@@ -87,7 +87,7 @@ class TestSessionsAdapter(private val sessionsViewModel : SessionsViewModel
         var captureButton = holder.view.findViewById<TextView>(R.id.sessions_card_button_capture)
 
         captureButton.tag = session.sessionId
-        if (session.state == STATUS.RUNNING && session.getTestReadableState() == TestReadableState.READABLE || session.getTestReadableState() == TestReadableState.RESOLVING) {
+        if (session.state == STATUS.RUNNING && (session.getTestReadableState() == TestReadableState.READABLE || session.getTestReadableState() == TestReadableState.RESOLVING))x {
             captureButton.visibility = View.VISIBLE
         } else {
             captureButton.visibility = View.GONE

--- a/app/src/main/java/org/rdtoolkit/util/InjectorUtils.kt
+++ b/app/src/main/java/org/rdtoolkit/util/InjectorUtils.kt
@@ -34,7 +34,8 @@ class InjectorUtils() {
             return object : ViewModelProvider.Factory {
                 override fun <T : ViewModel?> create(modelClass: Class<T>): T {
                     return CaptureViewModel(provideSessionRepository(context),
-                            provideDiagnosticsRepository(context)) as T
+                            provideDiagnosticsRepository(context),
+                            AppRepository(context)) as T
                 }
             }
         }

--- a/app/src/main/res/drawable/ic_baseline_timer_off_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_timer_off_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19.04,4.55l-1.42,1.42C16.07,4.74 14.12,4 12,4c-1.83,0 -3.53,0.55 -4.95,1.48l1.46,1.46C9.53,6.35 10.73,6 12,6c3.87,0 7,3.13 7,7 0,1.27 -0.35,2.47 -0.94,3.49l1.45,1.45C20.45,16.53 21,14.83 21,13c0,-2.12 -0.74,-4.07 -1.97,-5.61l1.42,-1.42 -1.41,-1.42zM15,1L9,1v2h6L15,1zM11,9.44l2,2L13,8h-2v1.44zM3.02,4L1.75,5.27 4.5,8.03C3.55,9.45 3,11.16 3,13c0,4.97 4.02,9 9,9 1.84,0 3.55,-0.55 4.98,-1.5l2.5,2.5 1.27,-1.27 -7.71,-7.71L3.02,4zM12,20c-3.87,0 -7,-3.13 -7,-7 0,-1.28 0.35,-2.48 0.95,-3.52l9.56,9.56c-1.03,0.61 -2.23,0.96 -3.51,0.96z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_capture_timer.xml
+++ b/app/src/main/res/layout/fragment_capture_timer.xml
@@ -27,7 +27,8 @@
             android:orientation="vertical"
             android:layout_margin="@dimen/single_pad"
             android:elevation="2dp"
-            android:visibility="gone">
+            android:visibility="visible"
+            >
 
             <net.vrgsoft.arcprogress.ArcProgressBar
                 android:id="@+id/capture_resolve_countdown"
@@ -40,6 +41,29 @@
                 app:arc_thickness="@dimen/timer_arc_thickness"
                 app:arc_unfinished_color="@color/color_progress_unfinished"
                 app:barrierDirection="start" />
+
+            <CheckBox
+                android:id="@+id/capture_timer_cbx_early_disclaimer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingTop="8dp"
+                android:visibility="gone"
+                android:text="@string/capture_timer_skip_disclaimer"
+                />
+
+            <Button
+                android:id="@+id/capture_btn_skip_timer"
+                style="@style/Button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                android:paddingTop="8dp"
+                android:drawableLeft="@drawable/ic_baseline_timer_off_24"
+                android:drawablePadding="5dp"
+                android:onClick="skipTimer"
+                android:text="@string/capture_timer_skip_button" />
+
+
         </LinearLayout>
 
         <LinearLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,4 +84,6 @@
     <string name="provision_instructions_title">Instructions</string>
     <string name="provision_timer_title">Test Timer</string>
     <string name="capture_job_aid_title">Job Aid</string>
+    <string name="capture_timer_skip_disclaimer">I confirm that tests which are read before the manufacturer\'s instructions indicate may produce incorrect results</string>
+    <string name="capture_timer_skip_button">Skip Timer and Read Result</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,4 +86,6 @@
     <string name="capture_job_aid_title">Job Aid</string>
     <string name="capture_timer_skip_disclaimer">I confirm that tests which are read before the manufacturer\'s instructions indicate may produce incorrect results</string>
     <string name="capture_timer_skip_button">Skip Timer and Read Result</string>
+    <string name="preferences_disclaimer_reset_summary">Reset any overrides or disclaimers on safe behavior</string>
+    <string name="preferences_disclaimer_reset_title">Reset disclaimers</string>
 </resources>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -10,4 +10,9 @@
         app:useSimpleSummaryProvider="true"
         android:defaultValue="system_default"
         />
+
+    <Preference
+        app:key="reset_disclaimers"
+        app:title="@string/preferences_disclaimer_reset_title"
+        app:summary="@string/preferences_disclaimer_reset_summary"/>
 </androidx.preference.PreferenceScreen>

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/interop/RdtIntentBuilder.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/interop/RdtIntentBuilder.kt
@@ -142,6 +142,14 @@ class RdtProvisioningIntentBuilder() : RdtIntentBuilder<RdtProvisioningIntentBui
     }
 
     /**
+     * Prevent users from overriding the timer and reading results which may be early.
+     */
+    fun disableEarlyReads() : RdtProvisioningIntentBuilder {
+        configBundle.getBundle(INTENT_EXTRA_RDT_CONFIG_FLAGS)!!.putString(FLAG_SESSION_NO_EARLY_READS, FLAG_VALUE_SET);
+        return this
+    }
+
+    /**
      * Apply a result response translator before returning the session intent
      */
     fun setResultResponseTranslator(responseTranslatorId : String) : RdtProvisioningIntentBuilder {

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/SessionFlags.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/SessionFlags.kt
@@ -2,6 +2,7 @@ package org.rdtoolkit.support.model.session
 
 const val FLAG_PREFIX_KEY = "FLAG_"
 
+const val FLAG_SESSION_NO_EARLY_READS = "FLAG_NO_EARLY_READS"
 const val FLAG_SESSION_NO_EXPIRATION_OVERRIDE = "FLAG_NO_OVERRIDE"
 const val FLAG_SESSION_TESTING_QA = "FLAG_TESTING_QA"
 


### PR DESCRIPTION
Adds the default ability for users to override the timer and read results which may be early.

This behavior can be disabled during provisioning with the `disableEarlyReads()` flag.

![2021-01-21 13 21 14](https://user-images.githubusercontent.com/155066/105395254-86635b80-5bec-11eb-903b-c452c9539877.jpg)
![2021-01-21 13 09 59](https://user-images.githubusercontent.com/155066/105395261-87948880-5bec-11eb-84de-419e38a1fb30.jpg)
