### PR TITLE
Metrics and First Pass on Event Models

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,9 +97,9 @@ android {
 dependencies {
     implementation project(':rd-toolkit-support')
 
-    implementation 'androidx.room:room-runtime:2.2.5'
+    implementation 'androidx.room:room-runtime:2.2.6'
     implementation 'androidx.work:work-runtime:2.4.0'
-    annotationProcessor 'androidx.room:room-compiler:2.2.5'
+    annotationProcessor 'androidx.room:room-compiler:2.2.6'
     kapt 'androidx.room:room-compiler:2.2.5'
 
     def nav_version = "2.3.1"
@@ -145,7 +145,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    testImplementation "androidx.room:room-testing:2.2.6"
+    androidTestImplementation "androidx.room:room-testing:2.2.6"
 
     // Feature module Support
     implementation "androidx.navigation:navigation-dynamic-features-fragment:$nav_version"

--- a/app/schemas/org.rdtoolkit.model.session.RdtDatabase/2.json
+++ b/app/schemas/org.rdtoolkit.model.session.RdtDatabase/2.json
@@ -1,0 +1,276 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "abb1723cab9dab37fe32f47bc114e643",
+    "entities": [
+      {
+        "tableName": "DbTestSession",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `state` TEXT NOT NULL, `testProfileId` TEXT NOT NULL, `timeStarted` INTEGER NOT NULL, `timeResolved` INTEGER NOT NULL, `timeExpired` INTEGER, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "testProfileId",
+            "columnName": "testProfileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeStarted",
+            "columnName": "timeStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeResolved",
+            "columnName": "timeResolved",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeExpired",
+            "columnName": "timeExpired",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `sessionType` TEXT NOT NULL, `provisionMode` TEXT NOT NULL, `classifierMode` TEXT NOT NULL, `provisionModeData` TEXT NOT NULL, `flavorText` TEXT, `flavorTextTwo` TEXT, `outputSessionTranslatorId` TEXT, `outputResultTranslatorId` TEXT, `cloudworksDns` TEXT, `cloudworksContext` TEXT, `flags` TEXT NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionType",
+            "columnName": "sessionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionMode",
+            "columnName": "provisionMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classifierMode",
+            "columnName": "classifierMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionModeData",
+            "columnName": "provisionModeData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flavorText",
+            "columnName": "flavorText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "flavorTextTwo",
+            "columnName": "flavorTextTwo",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputSessionTranslatorId",
+            "columnName": "outputSessionTranslatorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputResultTranslatorId",
+            "columnName": "outputResultTranslatorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cloudworksDns",
+            "columnName": "cloudworksDns",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cloudworksContext",
+            "columnName": "cloudworksContext",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionResult",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `timeRead` INTEGER, `mainImage` TEXT, `images` TEXT NOT NULL, `results` TEXT NOT NULL, `classifierResults` TEXT NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRead",
+            "columnName": "timeRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mainImage",
+            "columnName": "mainImage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "results",
+            "columnName": "results",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classifierResults",
+            "columnName": "classifierResults",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionMetrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `data` TEXT NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionTraceEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `eventTag` TEXT NOT NULL, `eventMessage` TEXT NOT NULL, `eventJson` TEXT, `sandboxObjectId` TEXT, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTag",
+            "columnName": "eventTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventMessage",
+            "columnName": "eventMessage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventJson",
+            "columnName": "eventJson",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sandboxObjectId",
+            "columnName": "sandboxObjectId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'abb1723cab9dab37fe32f47bc114e643')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/rdtoolkit/MigrationTest.kt
+++ b/app/src/androidTest/java/org/rdtoolkit/MigrationTest.kt
@@ -1,0 +1,73 @@
+package org.rdtoolkit
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.rdtoolkit.model.session.MIGRATION_1_2
+import org.rdtoolkit.model.session.RdtDatabase
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class MigrationTest {
+    private val TEST_DB = "migration-test"
+
+    // Array of all migrations
+    private val ALL_MIGRATIONS = arrayOf(
+            MIGRATION_1_2)
+
+    @get:Rule
+    val helper: MigrationTestHelper = MigrationTestHelper(
+            InstrumentationRegistry.getInstrumentation(),
+            RdtDatabase::class.java.canonicalName,
+            FrameworkSQLiteOpenHelperFactory()
+    )
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate1To2() {
+        var db = helper.createDatabase(TEST_DB, 1).apply {
+            // db has schema version 1. insert some data using SQL queries.
+            // You cannot use DAO classes because they expect the latest schema.
+            execSQL("INSERT INTO DbTestSession VALUES('9faf1fcf-f6a8-4551-a94d-6a219ed5e5d7','RUNNING','firstresponse_mal_pf',1611329424563,1611330624562,1611331224562);" +
+                    "INSERT INTO DbTestSession VALUES('20fcc2f1-a3c2-490d-b2a7-3e280ebf221c','QUEUED','firstresponse_mal_pf',1611329428387,1611329433387,1611330033387);" +
+                    "INSERT INTO DbTestSessionConfiguration VALUES('9faf1fcf-f6a8-4551-a94d-6a219ed5e5d7','TWO_PHASE','CRITERIA_SET_AND','PRE_POPULATE','mal_pf','Tedros Adhanom','#4SFS',NULL,NULL,NULL,NULL,'{\"FLAG_TESTING_QA\":\"TRUE\"}');" +
+                    "INSERT INTO DbTestSessionConfiguration VALUES('20fcc2f1-a3c2-490d-b2a7-3e280ebf221c','TWO_PHASE','CRITERIA_SET_AND','PRE_POPULATE','mal_pf','Tedros Adhanom','#4SFS',NULL,NULL,NULL,NULL,'{\"FLAG_TESTING_QA\":\"TRUE\"}');" +
+                    "INSERT INTO DbTestSessionResult VALUES('20fcc2f1-a3c2-490d-b2a7-3e280ebf221c',1611329457417,'/storage/emulated/0/Android/data/org.rdtoolkit/files/session_media/20fcc2f1-a3c2-490d-b2a7-3e280ebf221c/20210122_103055_cropped.jpg','{\"raw\":\"/storage/emulated/0/Android/data/org.rdtoolkit/files/session_media/20fcc2f1-a3c2-490d-b2a7-3e280ebf221c/20210122_103055.jpg\",\"cropped\":\"/storage/emulated/0/Android/data/org.rdtoolkit/files/session_media/20fcc2f1-a3c2-490d-b2a7-3e280ebf221c/20210122_103055_cropped.jpg\"}','{\"mal_pf\":\"mal_pf_pos\"}','{\"mal_pf\":\"mal_pf_pos\"}');")
+            // Prepare for the next version.
+            close()
+        }
+
+        // Re-open the database with version 2 and provide
+        // MIGRATION_1_2 as the migration process.
+        db = helper.runMigrationsAndValidate(TEST_DB, 2, true, MIGRATION_1_2)
+
+        // MigrationTestHelper automatically verifies the schema changes,
+        // but you need to validate that the data was migrated properly.
+    }
+
+
+    @Test
+    @Throws(IOException::class)
+    fun migrateAll() {
+        // Create earliest version of the database.
+        helper.createDatabase(TEST_DB, 1).apply {
+            close()
+        }
+
+        // Open latest version of the database. Room will validate the schema
+        // once all migrations execute.
+        Room.databaseBuilder(
+                InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                RdtDatabase::class.java,
+                        TEST_DB
+        ).addMigrations(*ALL_MIGRATIONS).build().apply {
+            getOpenHelper().getWritableDatabase()
+            close()
+        }
+    }
+}

--- a/app/src/androidTest/java/org/rdtoolkit/TestObjects.kt
+++ b/app/src/androidTest/java/org/rdtoolkit/TestObjects.kt
@@ -26,7 +26,8 @@ object Constants {
             Date(Date().time - 1000),
             Date(Date().time - 750),
             Date(Date().time - 250),
-            null)
+            null,
+            TestSession.Metrics(HashMap()))
 
 
     @JvmField
@@ -37,7 +38,6 @@ object Constants {
             Date(Date().time - 1000),
             Date(Date().time - 750),
             Date(Date().time - 250),
-            TestResultsSampleValues)
-
-
+            TestResultsSampleValues,
+            TestSession.Metrics(HashMap()))
 }

--- a/app/src/main/java/org/rdtoolkit/interop/JsonObjectMappings.kt
+++ b/app/src/main/java/org/rdtoolkit/interop/JsonObjectMappings.kt
@@ -77,6 +77,20 @@ class ResultToJson() : Mapper<TestSession.TestResult, JSONObject> {
     }
 }
 
+class MetricsToJson() : Mapper<TestSession.Metrics, JSONObject> {
+    override fun map(input: TestSession.Metrics): JSONObject {
+        val root = JSONObject()
+
+        val data = JSONObject()
+        for (entry in input.data) {
+            data.put(entry.key, entry.value)
+        }
+        root.put("data", data)
+
+        return root
+    }
+}
+
 
 class SessionToJson(val stripSensitive : Boolean = false) : Mapper<TestSession, JSONObject> {
     override fun map(input: TestSession): JSONObject {
@@ -96,6 +110,8 @@ class SessionToJson(val stripSensitive : Boolean = false) : Mapper<TestSession, 
         input.result?.let {
             root.put("result", ResultToJson().map(it))
         }
+
+        root.put("metrics", MetricsToJson().map(input.metrics))
 
         return root
     }

--- a/app/src/main/java/org/rdtoolkit/model/Converters.kt
+++ b/app/src/main/java/org/rdtoolkit/model/Converters.kt
@@ -46,7 +46,7 @@ class Converters {
     fun stringToClassiferMode(value: String): ClassifierMode { return ClassifierMode.valueOf(value) }
 
     @TypeConverter
-    fun fromString(value: String?): Map<String?, String?>? {
+    fun stringToStringMap(value: String?): Map<String?, String?>? {
         val mapType: Type = object : TypeToken<Map<String?, String?>?>() {}.getType()
         return Gson().fromJson(value, mapType)
     }

--- a/app/src/main/java/org/rdtoolkit/model/session/DbEntities.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/DbEntities.kt
@@ -1,9 +1,6 @@
 package org.rdtoolkit.model.session
 
-import androidx.room.Embedded
-import androidx.room.Entity
-import androidx.room.PrimaryKey
-import androidx.room.Relation
+import androidx.room.*
 import org.rdtoolkit.support.model.session.*
 import java.util.*
 
@@ -45,6 +42,27 @@ data class DbTestSessionResult(
         val classifierResults: MutableMap<String, String>
 )
 
+@Entity
+/**
+ * Metadata metrics information about test sessions
+ */
+data class DbTestSessionMetrics (
+        @PrimaryKey val sessionId: String,
+        val data: MutableMap<String, String>
+)
+
+@Entity
+/**
+ * Discrete, loggable events for forensics and monitoring of test sessions
+ */
+data class DbTestSessionTraceEvent (
+        @PrimaryKey val sessionId: String,
+        val timestamp : String,
+        val eventTag : String,
+        val eventMessage : String,
+        val eventJson : String?,
+        val sandboxObjectId: String?
+)
 
 @Entity
 /**
@@ -71,5 +89,7 @@ data class DataTestSession (
         @Relation(parentColumn = "sessionId", entityColumn = "sessionId")
         val config : DbTestSessionConfiguration,
         @Relation(parentColumn = "sessionId", entityColumn = "sessionId")
-        val result: DbTestSessionResult?
+        val result: DbTestSessionResult?,
+        @Relation(parentColumn = "sessionId", entityColumn = "sessionId")
+        val metrics: DbTestSessionMetrics?
 )

--- a/app/src/main/java/org/rdtoolkit/model/session/Mapping.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Mapping.kt
@@ -9,7 +9,8 @@ class SessionToDataMapper() : Mapper<TestSession, DataTestSession> {
                 DbTestSession(input.sessionId, input.state, input.testProfileId,
                         input.timeStarted, input.timeResolved, input.timeExpired),
                 ConfigToDataMapper(input.sessionId).map(input.configuration),
-                ResultToDataMapper(input.sessionId).map(input.result)
+                ResultToDataMapper(input.sessionId).map(input.result),
+                MetricsToDataMapper(input.sessionId).map(input.metrics)
         )
     }
 }
@@ -22,7 +23,8 @@ class DataToSessionMapper() : Mapper<DataTestSession, TestSession> {
                 session.timeStarted,
                 session.timeResolved,
                 session.timeExpired,
-                DataToResultMapper().map(input.result))
+                DataToResultMapper().map(input.result),
+                DataToMetricsMapper().map(input.metrics))
     }
 }
 
@@ -47,5 +49,21 @@ class ConfigToDataMapper(val sessionId : String) : Mapper<TestSession.Configurat
 class DataToConfigMapper() : Mapper<DbTestSessionConfiguration, TestSession.Configuration> {
     override fun map(input : DbTestSessionConfiguration): TestSession.Configuration {
         return TestSession.Configuration(input.sessionType, input.provisionMode, input.classifierMode, input.provisionModeData, input.flavorText, input.flavorTextTwo, input.outputSessionTranslatorId, input.outputResultTranslatorId, input.cloudworksDns, input.cloudworksContext, input.flags)
+    }
+}
+
+class MetricsToDataMapper(val sessionId : String) : Mapper<TestSession.Metrics, DbTestSessionMetrics> {
+    override fun map(input: TestSession.Metrics): DbTestSessionMetrics {
+        return DbTestSessionMetrics(sessionId, input.data)
+
+    }
+}
+
+class DataToMetricsMapper() : Mapper<DbTestSessionMetrics?, TestSession.Metrics> {
+    override fun map(input : DbTestSessionMetrics?): TestSession.Metrics {
+        if (input == null) {
+            return TestSession.Metrics(HashMap())
+        }
+        return TestSession.Metrics(input.data)
     }
 }

--- a/app/src/main/java/org/rdtoolkit/model/session/Migrations.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Migrations.kt
@@ -1,0 +1,14 @@
+package org.rdtoolkit.model.session
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("CREATE TABLE IF NOT EXISTS `DbTestSessionMetrics` (`sessionId` TEXT NOT NULL, `data` TEXT NOT NULL, PRIMARY KEY(`sessionId`))")
+        database.execSQL("CREATE TABLE IF NOT EXISTS `DbTestSessionTraceEvent` " +
+                "(`sessionId` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `eventTag` TEXT NOT NULL, " +
+                "`eventMessage` TEXT NOT NULL, `eventJson` TEXT, `sandboxObjectId` TEXT, " +
+                "PRIMARY KEY(`sessionId`))")
+    }
+}

--- a/app/src/main/java/org/rdtoolkit/model/session/Room.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Room.kt
@@ -89,7 +89,9 @@ fun getDatabase(context: Context): RdtDatabase {
         if (!::INSTANCE.isInitialized) {
             INSTANCE = Room.databaseBuilder(context.applicationContext,
                     RdtDatabase::class.java,
-                    "rdtdatabase").build()
+                    "rdtdatabase")
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
         }
     }
     return INSTANCE

--- a/app/src/main/java/org/rdtoolkit/model/session/Room.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Room.kt
@@ -28,6 +28,9 @@ interface TestSessionDao {
     @Query("SELECT * FROM DbTestSessionConfiguration WHERE sessionId = :sessionId")
     fun loadConfig(sessionId: String): DbTestSessionConfiguration
 
+    @Query("SELECT * FROM DbTestSessionMetrics WHERE sessionId = :sessionId")
+    fun loadMetrics(sessionId: String): DbTestSessionMetrics
+
     @Query("SELECT sessionId FROM DbTestSession WHERE state = 'RUNNING' and (timeExpired is null or :now < timeExpired)")
     fun getPendingSessionIds(now : Date) : List<String>
 
@@ -62,7 +65,8 @@ interface TestSessionDao {
     fun loadDataSession(sessionId: String): DataTestSession {
         return DataTestSession(load(sessionId),
                 loadConfig(sessionId),
-                loadResult(sessionId)
+                loadResult(sessionId),
+                loadMetrics(sessionId)
         )
     }
 
@@ -72,7 +76,7 @@ interface TestSessionDao {
 }
 
 @Database(entities = [DbTestSession::class, DbTestSessionConfiguration::class,
-    DbTestSessionResult::class], version = 1)
+    DbTestSessionResult::class, DbTestSessionMetrics::class, DbTestSessionTraceEvent::class], version = 2)
 @TypeConverters(Converters::class)
 abstract class RdtDatabase : RoomDatabase() {
     abstract fun testSessionDao(): TestSessionDao

--- a/app/src/main/java/org/rdtoolkit/model/session/Room.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Room.kt
@@ -16,6 +16,9 @@ interface TestSessionDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun saveConfig(session : DbTestSessionConfiguration)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun saveMetrics(session : DbTestSessionMetrics)
+
     @Query("SELECT count(*) FROM DbTestSession WHERE sessionId = :sessionId")
     fun getSessionCount(sessionId: String): Int
 
@@ -48,6 +51,7 @@ interface TestSessionDao {
         save(dbSession.session)
         saveConfig(dbSession.config)
         dbSession.result?.let{ saveResult(it) }
+        dbSession.metrics?.let { saveMetrics(it) }
     }
 
     @Transaction

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
@@ -112,6 +112,12 @@ public class CaptureActivity extends LocaleAwareCompatActivity implements Compon
             }
         });
 
+        pamphletViewModel.onLastPage.observe(this, value -> {
+            if (value) {
+                captureViewModel.recordJobAidViewed();
+            }
+        });
+
         //Needed to ensure this declarative check processes.
         captureViewModel.getRequireWorkCheck().observe(this, result ->{
 

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureViewModel.kt
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureViewModel.kt
@@ -63,6 +63,8 @@ class CaptureViewModel(var sessionRepository: SessionRepository,
 
     private val allowOverrideValue : MutableLiveData<Boolean> = MutableLiveData()
 
+    private var totalNumberOfCaptureAttempts = 0
+
     private val earlyReadsEnabled : LiveData<Boolean> =  Transformations.map(testSession) {
         FLAG_VALUE_SET != it.configuration.flags[FLAG_SESSION_NO_EARLY_READS]
     }
@@ -102,6 +104,15 @@ class CaptureViewModel(var sessionRepository: SessionRepository,
 
     val requireWorkCheck = Transformations.map(CombinedLiveData(needsWorkCheck, workChecked)) {
         it.first && !it.second
+    }
+
+    private fun recordCaptureAttempt() {
+        totalNumberOfCaptureAttempts++
+        testSession.value!!.metrics.setCaptureAttempts(totalNumberOfCaptureAttempts)
+    }
+
+    fun recordJobAidViewed() {
+        testSession.value!!.metrics.setJobAidViewed();
     }
 
     private fun areClassifierOutcomesDifferent(it: TestSession.TestResult): Boolean {
@@ -182,6 +193,7 @@ class CaptureViewModel(var sessionRepository: SessionRepository,
 
     fun setCapturedImage(imageData: Pair<String, MutableMap<String, String>>) {
         if (rawImageCapturePath.value != imageData.first) {
+            recordCaptureAttempt()
             rawImageCapturePath.value = imageData.first
 
             val result = testSessionResult.value!!

--- a/app/src/main/java/org/rdtoolkit/ui/instruct/PamphletViewModel.java
+++ b/app/src/main/java/org/rdtoolkit/ui/instruct/PamphletViewModel.java
@@ -2,11 +2,13 @@ package org.rdtoolkit.ui.instruct;
 
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Transformations;
 import androidx.lifecycle.ViewModel;
 
 import org.rdtoolkit.model.diagnostics.Page;
 import org.rdtoolkit.model.diagnostics.Pamphlet;
 import org.rdtoolkit.model.session.AppRepository;
+import org.rdtoolkit.util.CombinedLiveData;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,21 +19,25 @@ public class PamphletViewModel extends ViewModel {
     private Page disclaimerPage;
     private AppRepository appRepository;
 
-    private MutableLiveData<Page> currentPage;
+    private MutableLiveData<Page> currentPage = new MutableLiveData<>();
     private MutableLiveData<Boolean> disclaimerAcknowledged;
 
-    public PamphletViewModel(DisclaimerPage disclaimerPage, AppRepository appRepository) {
-        this.disclaimerPage = disclaimerPage;
-        this.appRepository = appRepository;
-        currentPage = new MutableLiveData();
-        disclaimerAcknowledged = new MutableLiveData(appRepository.hasAcknowledgedDisclaimer());
-    }
-
     private MutableLiveData<List<Page>> pageList = new MutableLiveData<>();
+
+    public LiveData<Boolean> onLastPage = Transformations.map(new CombinedLiveData<>(currentPage, pageList), it ->
+            it.component1().equals(it.component2().get(it.component2().size()-1)));
 
     private int pageNumber = PAGE_NONE;
 
     private Pamphlet sourcePamphlet;
+
+
+    public PamphletViewModel(DisclaimerPage disclaimerPage, AppRepository appRepository) {
+        this.disclaimerPage = disclaimerPage;
+        this.appRepository = appRepository;
+        disclaimerAcknowledged = new MutableLiveData(appRepository.hasAcknowledgedDisclaimer());
+    }
+
 
     public LiveData<Boolean> isDisclaimerAcknowledged() {
         return disclaimerAcknowledged;

--- a/app/src/main/java/org/rdtoolkit/ui/provision/ProvisionActivity.java
+++ b/app/src/main/java/org/rdtoolkit/ui/provision/ProvisionActivity.java
@@ -99,6 +99,12 @@ public class ProvisionActivity extends LocaleAwareCompatActivity {
             }
         });
 
+        pamphletViewModel.onLastPage.observe(this, value -> {
+            if (value) {
+               provisionViewModel.recordInstructionsViewed();
+            }
+        });
+
         NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
         NavigationUI.setupActionBarWithNavController(this, navController, appBarConfiguration);
         NavigationUI.setupWithNavController(navView, navController);

--- a/app/src/main/java/org/rdtoolkit/ui/provision/ProvisionViewModel.kt
+++ b/app/src/main/java/org/rdtoolkit/ui/provision/ProvisionViewModel.kt
@@ -11,6 +11,7 @@ import org.rdtoolkit.support.model.session.ProvisionMode
 import org.rdtoolkit.support.model.session.STATUS
 import org.rdtoolkit.model.session.SessionRepository
 import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.setInstructionsViewed
 import java.util.*
 import kotlin.collections.HashMap
 
@@ -140,6 +141,10 @@ class ProvisionViewModel(var sessionRepository: SessionRepository,
             job.join();
         }
         return session;
+    }
+
+    fun recordInstructionsViewed() {
+        metrics.setInstructionsViewed();
     }
 
     init {

--- a/app/src/main/java/org/rdtoolkit/ui/provision/ProvisionViewModel.kt
+++ b/app/src/main/java/org/rdtoolkit/ui/provision/ProvisionViewModel.kt
@@ -12,6 +12,7 @@ import org.rdtoolkit.support.model.session.STATUS
 import org.rdtoolkit.model.session.SessionRepository
 import org.rdtoolkit.support.model.session.TestSession
 import java.util.*
+import kotlin.collections.HashMap
 
 const val TAG = "ProvisionViewModel"
 
@@ -21,6 +22,8 @@ class ProvisionViewModel(var sessionRepository: SessionRepository,
 
     private lateinit var sessionId: String
     private var sessionConfiguration: MutableLiveData<TestSession.Configuration> = MutableLiveData()
+
+    private var metrics = TestSession.Metrics(HashMap())
 
     private val viewInstructions: MutableLiveData<Boolean>
 
@@ -125,7 +128,8 @@ class ProvisionViewModel(var sessionRepository: SessionRepository,
                 Date(),
                 dateTimeToResolve,
                 dateTimeToExpire,
-                null)
+                null,
+                metrics)
 
         val job = viewModelScope.launch(Dispatchers.IO) {
             sessionRepository.write(session)

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -84,4 +84,8 @@
     <string name="provision_instructions_title">Instructions</string>
     <string name="provision_timer_title">Test Timer</string>
     <string name="capture_job_aid_title">Job Aid</string>
+    <string name="capture_timer_skip_disclaimer">I confirm that tests which are read before the manufacturer\'s instructions indicate may produce incorrect results</string>
+    <string name="capture_timer_skip_button">Skip Timer and Read Result</string>
+    <string name="preferences_disclaimer_reset_summary">Reset any overrides or disclaimers on safe behavior</string>
+    <string name="preferences_disclaimer_reset_title">Reset disclaimers</string>
 </resources>

--- a/app/src/test/java/org/rdtoolkit/TestObjects.kt
+++ b/app/src/test/java/org/rdtoolkit/TestObjects.kt
@@ -26,7 +26,8 @@ object TestObjects {
             Date(Date().time - 1000),
             Date(Date().time - 750),
             Date(Date().time - 250),
-            null)
+            null,
+            TestSession.Metrics(HashMap()))
 
 
     @JvmField
@@ -37,7 +38,6 @@ object TestObjects {
             Date(Date().time - 1000),
             Date(Date().time - 750),
             Date(Date().time - 250),
-            TestResultsSampleValues)
-
-
+            TestResultsSampleValues,
+            TestSession.Metrics(HashMap()))
 }

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/interop/IntentObjectMappings.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/interop/IntentObjectMappings.kt
@@ -163,7 +163,8 @@ class BundleToSession : Mapper<Bundle, TestSession> {
                 Date(input.getLong(INTENT_EXTRA_RDT_SESSION_TIME_STARTED)),
                 Date(input.getLong(INTENT_EXTRA_RDT_SESSION_TIME_RESOLVED)),
                 input.get(INTENT_EXTRA_RDT_SESSION_TIME_EXPIRED)?.let { Date(input.getLong(INTENT_EXTRA_RDT_SESSION_TIME_EXPIRED))},
-                input.getBundle(INTENT_EXTRA_RDT_RESULT_BUNDLE)?.let { BundleToResult().map(it) }
+                input.getBundle(INTENT_EXTRA_RDT_RESULT_BUNDLE)?.let { BundleToResult().map(it) },
+                TestSession.Metrics(HashMap())
         )
     }
 }

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/DomainModels.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/DomainModels.kt
@@ -10,7 +10,8 @@ data class TestSession (
         val timeStarted : Date,
         val timeResolved : Date,
         val timeExpired : Date?,
-        var result: TestResult?
+        var result: TestResult?,
+        val metrics: Metrics
 ) {
     fun getTestReadableState() : TestReadableState {
         if (timeStarted == null) {
@@ -44,6 +45,10 @@ data class TestSession (
             val cloudworksDns: String?,
             val cloudworksContext: String?,
             val flags: Map<String, String>
+    )
+
+    data class Metrics(
+            val data: MutableMap<String, String>
     )
 }
 

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/Metrics.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/Metrics.kt
@@ -1,0 +1,19 @@
+package org.rdtoolkit.support.model.session
+
+const val METRICS_NUMBER_OF_CAPTURE_ATTEMPTS = "image_capture_attempts"
+const val METRICS_VALUE_TRUE = "true"
+const val METRICS_INSTRUCTIONS_VIEWED = "instructions_viewed"
+const val METRICS_JOB_AID_VIEWED = "job_aid_viewed"
+
+fun TestSession.Metrics.setCaptureAttempts(numberOfAttempts: Int) {
+    this.data[METRICS_NUMBER_OF_CAPTURE_ATTEMPTS] = numberOfAttempts.toString()
+}
+
+fun TestSession.Metrics.setInstructionsViewed() {
+    this.data[METRICS_INSTRUCTIONS_VIEWED] = METRICS_VALUE_TRUE
+}
+
+fun TestSession.Metrics.setJobAidViewed() {
+    this.data[METRICS_JOB_AID_VIEWED] = METRICS_VALUE_TRUE
+}
+


### PR DESCRIPTION
Creates models for a flat, fixed length metrics set (one model per session), and logged events (multiple per session).

Initial metrics created for:
 * Number of image capture events
 * User viewed instructions
 * User viewed job aid

Metrics are included in uploaded session record JSON, IE:

```
        "metrics": {
            "data": {
                "instructions_viewed": "true",
                "image_capture_attempts": "3"
            }
        }
```