### PR TITLE
App Notifications Config Shortcut

### DIFF
--- a/app/src/main/java/org/rdtoolkit/ui/preferences/ToolkitPreferencesFragment.java
+++ b/app/src/main/java/org/rdtoolkit/ui/preferences/ToolkitPreferencesFragment.java
@@ -1,17 +1,13 @@
 package org.rdtoolkit.ui.preferences;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.util.Pair;
 
 import androidx.core.os.ConfigurationCompat;
@@ -29,11 +25,14 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.rdtoolkit.service.TestTimerServiceKt.CHANNEL_ID_FIRE;
+
 public class ToolkitPreferencesFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener {
 
     static final String LANG_CODE_SYSTEM_DEFAULT = "system_default";
     static final String PREFERENCE_KEY_LANGUAGE = "language";
     static final String PREFERENCE_KEY_RESET_DISCLAIMERS = "reset_disclaimers";
+    static final String PREFERENCE_KEY_NOTIFICATIONS = "notification_settings";
     static final String TAG = ToolkitPreferencesFragment.class.getName();
 
     LinkedHashMap<String, Locale> locales;
@@ -47,6 +46,15 @@ public class ToolkitPreferencesFragment extends PreferenceFragmentCompat impleme
         findPreference(PREFERENCE_KEY_RESET_DISCLAIMERS).setOnPreferenceClickListener(it -> {
             new AppRepository(this.getContext()).clearDisclaimers();
             it.setEnabled(false);
+            return true;
+        });
+
+        findPreference(PREFERENCE_KEY_NOTIFICATIONS).setOnPreferenceClickListener(it -> {
+            Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
+            intent.putExtra(Settings.EXTRA_CHANNEL_ID, CHANNEL_ID_FIRE);
+            startActivity(intent);
+
             return true;
         });
     }

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -88,4 +88,6 @@
     <string name="capture_timer_skip_button">Pular cronômetro e ler o resultado</string>
     <string name="preferences_disclaimer_reset_summary">Redefina quaisquer substituições ou isenções de responsabilidade sobre comportamento seguro</string>
     <string name="preferences_disclaimer_reset_title">Redefinir isenções de responsabilidade</string>
+    <string name="preferences_notifications_timers_title">Configure timer notification</string>
+    <string name="preferences_notifications_timers_summary">Change the notification behaviors (sound, vibration, etc) for when tests are ready</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -88,4 +88,6 @@
     <string name="capture_timer_skip_button">Skip Timer and Read Result</string>
     <string name="preferences_disclaimer_reset_summary">Reset any overrides or disclaimers on safe behavior</string>
     <string name="preferences_disclaimer_reset_title">Reset disclaimers</string>
+    <string name="preferences_notifications_timers_title">Configure timer notification</string>
+    <string name="preferences_notifications_timers_summary">Change the notification behaviors (sound, vibration, etc) for when tests are ready</string>
 </resources>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -12,6 +12,11 @@
         />
 
     <Preference
+        app:key="notification_settings"
+        app:title="@string/preferences_notifications_timers_title"
+        app:summary="@string/preferences_notifications_timers_summary"/>
+
+    <Preference
         app:key="reset_disclaimers"
         app:title="@string/preferences_disclaimer_reset_title"
         app:summary="@string/preferences_disclaimer_reset_summary"/>


### PR DESCRIPTION
Enable more straightforward access to App Notification config to make it easier to make App Timers more (or less) noisy.

![2021-01-22 15 58 33](https://user-images.githubusercontent.com/155066/105546223-1c6db380-5ccb-11eb-90ea-933eaddbf819.jpg)
