### PR TITLE
Move low-battery network spooling to preference

### DIFF
--- a/app/src/main/java/org/rdtoolkit/model/session/AppRepository.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/AppRepository.kt
@@ -2,6 +2,7 @@ package org.rdtoolkit.model.session
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
 import org.rdtoolkit.R
 
 class AppRepository(private val context : Context) {
@@ -21,6 +22,10 @@ class AppRepository(private val context : Context) {
         prefs().edit().putBoolean(PREFERENCE_EARLY_TIMER_DISCLAIMER, acknowledged).apply()
     }
 
+    fun isNetworkRestrictedByBattery() : Boolean {
+        return prefs().getBoolean(PREFERENCE_RESTRICT_NETWORK_BATTERY, false)
+    }
+
     fun clearDisclaimers() {
         var editor = prefs().edit()
         editor.remove(PREFERENCE_ACKNOWLEDGED_DISCLAIMER)
@@ -29,14 +34,12 @@ class AppRepository(private val context : Context) {
     }
 
     private fun prefs(): SharedPreferences {
-        return context.getSharedPreferences(context.getString(R.string.default_preference_key)
-                , Context.MODE_PRIVATE)!!
+        return PreferenceManager.getDefaultSharedPreferences(context)!!
     }
 
     companion object {
         const val PREFERENCE_ACKNOWLEDGED_DISCLAIMER = "user_acknwoledged_disclaimer"
         const val PREFERENCE_EARLY_TIMER_DISCLAIMER = "user_acknowleged_early_timer"
-
-
+        const val PREFERENCE_RESTRICT_NETWORK_BATTERY = "restrict_network_battery"
     }
 }

--- a/app/src/main/java/org/rdtoolkit/processing/WorkCoordinator.kt
+++ b/app/src/main/java/org/rdtoolkit/processing/WorkCoordinator.kt
@@ -3,6 +3,7 @@ package org.rdtoolkit.processing
 import android.content.Context
 import androidx.work.*
 import androidx.work.WorkRequest.MIN_BACKOFF_MILLIS
+import org.rdtoolkit.model.session.AppRepository
 import org.rdtoolkit.processing.ImageSubmissionWorker.Companion.DATA_FILE_PATH
 import org.rdtoolkit.processing.ImageSubmissionWorker.Companion.DATA_MEDIA_KEY
 import org.rdtoolkit.processing.ImageSubmissionWorker.Companion.TAG_MEDIA
@@ -44,7 +45,7 @@ class WorkCoordinator(val context : Context) {
                 .addTag(session.sessionId)
                 .addTag(TAG_SESSION)
                 .setInputData(sessionData)
-                .setConstraints(networkConstraints)
+                .setConstraints(getNetworkConstraints())
                 .setBackoffCriteria(
                         BackoffPolicy.EXPONENTIAL,
                         MIN_BACKOFF_MILLIS,
@@ -94,7 +95,7 @@ class WorkCoordinator(val context : Context) {
                 .addTag(session.sessionId)
                 .addTag(TAG_MEDIA)
                 .setInputData(imageData)
-                .setConstraints(networkConstraints)
+                .setConstraints(getNetworkConstraints())
                 .setBackoffCriteria(
                         BackoffPolicy.EXPONENTIAL,
                         MIN_BACKOFF_MILLIS,
@@ -102,11 +103,15 @@ class WorkCoordinator(val context : Context) {
                 .build()
     }
 
-    companion object {
-        val networkConstraints: Constraints = Constraints.Builder()
+    private fun getNetworkConstraints() : Constraints {
+        return Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
-                .setRequiresBatteryNotLow(true)
+                .setRequiresBatteryNotLow(AppRepository(context).isNetworkRestrictedByBattery())
                 .build()
+
+    }
+
+    companion object {
 
         @JvmStatic
         fun getUniqueWorkRootTag(sessionId : String) : String{

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,4 +91,6 @@
     <string name="preferences_notifications_timers_title">Configure timer notification</string>
     <string name="preferences_notifications_timers_summary">Change the notification behaviors (sound, vibration, etc) for when tests are ready</string>
     <string name="fragment_capture_review_instructions">Are you sure?\n\nAccording to automated review, your choices might need another look. You can use the Job Aid for help interpreting the test result.</string>
+    <string name="preferences_network_battery_title">Enable network power limit</string>
+    <string name="preferences_network_battery_on_summary">Network will be disabled when battery is low</string>
 </resources>

--- a/app/src/main/res/xml/main_preferences.xml
+++ b/app/src/main/res/xml/main_preferences.xml
@@ -11,6 +11,12 @@
         android:defaultValue="system_default"
         />
 
+    <SwitchPreference
+        android:defaultValue="false"
+        android:summaryOn="@string/preferences_network_battery_on_summary"
+        android:title="@string/preferences_network_battery_title"
+        android:key="restrict_network_battery" />
+
     <Preference
         app:key="notification_settings"
         app:title="@string/preferences_notifications_timers_title"
@@ -20,4 +26,5 @@
         app:key="reset_disclaimers"
         app:title="@string/preferences_disclaimer_reset_title"
         app:summary="@string/preferences_disclaimer_reset_summary"/>
+
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Initially, network submission of cloudworks events were set to be disabled when battery was low, which was causing confusing behavior for some users.

This retains the behavior, but makes it an opt-in setting which isn't enabled by default.

![image](https://user-images.githubusercontent.com/155066/106509445-a40dac00-649b-11eb-9a21-a2f376db5ff7.png)
