### PR TITLE
CloudworksAPI - set OkHttpClient read/write timeout to 0.

### DIFF
--- a/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
+++ b/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
@@ -14,10 +14,16 @@ import java.util.concurrent.TimeUnit
 
 
 class CloudworksApi(dns: String, val sessionId : String, val context : Context) {
+    /**
+     * Connection read and write timeouts in seconds
+     */
+    val CONNECTION_READ_TIMEOUT = 120
+    val CONNECTION_WRITE_TIMEOUT = 120
+
     private val dns = dns.removeSuffix("/")
     private val client = OkHttpClient.Builder()
-            .readTimeout(0, TimeUnit.SECONDS)
-            .writeTimeout(0, TimeUnit.SECONDS)
+            .readTimeout(CONNECTION_READ_TIMEOUT.toLong(), TimeUnit.SECONDS)
+            .writeTimeout(CONNECTION_WRITE_TIMEOUT.toLong(), TimeUnit.SECONDS)
             .build()
 
     fun submitSessionJson(session: TestSession) {

--- a/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
+++ b/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
@@ -1,8 +1,6 @@
 package org.rdtoolkit.processing
 
 import android.content.Context
-import android.util.Log
-import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -12,11 +10,15 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.rdtoolkit.interop.SessionToJson
 import org.rdtoolkit.support.model.session.TestSession
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 
 class CloudworksApi(dns: String, val sessionId : String, val context : Context) {
     private val dns = dns.removeSuffix("/")
-    private val client = OkHttpClient()
+    private val client = OkHttpClient.Builder()
+            .readTimeout(0, TimeUnit.SECONDS)
+            .writeTimeout(0, TimeUnit.SECONDS)
+            .build()
 
     fun submitSessionJson(session: TestSession) {
         val json = SessionToJson(true).map(session)

--- a/app/src/main/java/org/rdtoolkit/processing/Workers.kt
+++ b/app/src/main/java/org/rdtoolkit/processing/Workers.kt
@@ -52,6 +52,7 @@ class ImageSubmissionWorker(appContext: Context, workerParams: WorkerParameters)
         try {
             CloudworksApi(cloudworksEndpoint, sessionId, this.applicationContext).submitSessionMedia(key, file)
         } catch(e : Exception) {
+            e.printStackTrace()
             return Result.retry()
         }
 


### PR DESCRIPTION
This PR is created to address the client side timeout issues with image uploads.

OkHttpClient read/write timeout values changed from10s (default) to 0 (unlimited). 

Unlimited timeouts could be replaced with actual values if that's more appropriate. 

