### PR TITLE
Verbose Capture Sessions

### DIFF
--- a/app/schemas/org.rdtoolkit.model.session.RdtDatabase/3.json
+++ b/app/schemas/org.rdtoolkit.model.session.RdtDatabase/3.json
@@ -1,0 +1,291 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "5ec611f1d5fada8c60c7a14de3af0b7e",
+    "entities": [
+      {
+        "tableName": "DbTestSession",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `state` TEXT NOT NULL, `testProfileId` TEXT NOT NULL, `timeStarted` INTEGER NOT NULL, `timeResolved` INTEGER NOT NULL, `timeExpired` INTEGER, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "testProfileId",
+            "columnName": "testProfileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeStarted",
+            "columnName": "timeStarted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeResolved",
+            "columnName": "timeResolved",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeExpired",
+            "columnName": "timeExpired",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionConfiguration",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `sessionType` TEXT NOT NULL, `provisionMode` TEXT NOT NULL, `classifierMode` TEXT NOT NULL, `provisionModeData` TEXT NOT NULL, `flavorText` TEXT, `flavorTextTwo` TEXT, `outputSessionTranslatorId` TEXT, `outputResultTranslatorId` TEXT, `cloudworksDns` TEXT, `cloudworksContext` TEXT, `flags` TEXT NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionType",
+            "columnName": "sessionType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionMode",
+            "columnName": "provisionMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classifierMode",
+            "columnName": "classifierMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionModeData",
+            "columnName": "provisionModeData",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "flavorText",
+            "columnName": "flavorText",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "flavorTextTwo",
+            "columnName": "flavorTextTwo",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputSessionTranslatorId",
+            "columnName": "outputSessionTranslatorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "outputResultTranslatorId",
+            "columnName": "outputResultTranslatorId",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cloudworksDns",
+            "columnName": "cloudworksDns",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "cloudworksContext",
+            "columnName": "cloudworksContext",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "flags",
+            "columnName": "flags",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionResult",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `timeRead` INTEGER, `mainImage` TEXT, `images` TEXT NOT NULL, `results` TEXT NOT NULL, `classifierResults` TEXT NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeRead",
+            "columnName": "timeRead",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mainImage",
+            "columnName": "mainImage",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "results",
+            "columnName": "results",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classifierResults",
+            "columnName": "classifierResults",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionMetrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `data` TEXT NOT NULL, PRIMARY KEY(`sessionId`))",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "DbTestSessionTraceEvent",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `eventTag` TEXT NOT NULL, `eventMessage` TEXT NOT NULL, `eventJson` TEXT, `sandboxObjectId` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventTag",
+            "columnName": "eventTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventMessage",
+            "columnName": "eventMessage",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "eventJson",
+            "columnName": "eventJson",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sandboxObjectId",
+            "columnName": "sandboxObjectId",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "sessionId_index",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `sessionId_index` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5ec611f1d5fada8c60c7a14de3af0b7e')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/rdtoolkit/BuilderConfigTests.kt
+++ b/app/src/androidTest/java/org/rdtoolkit/BuilderConfigTests.kt
@@ -1,0 +1,43 @@
+package org.rdtoolkit
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.rdtoolkit.support.interop.BundleToConfiguration
+import org.rdtoolkit.support.interop.RdtIntentBuilder
+import org.rdtoolkit.support.interop.RdtIntentBuilder.Companion.INTENT_EXTRA_RDT_CONFIG_BUNDLE
+import org.rdtoolkit.support.interop.RdtIntentBuilder.Companion.forProvisioning
+import org.rdtoolkit.support.interop.RdtProvisioningIntentBuilder
+import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.isCloudworksActive
+import org.rdtoolkit.support.model.session.isComprehensiveImageSubmissionEnabled
+import org.rdtoolkit.support.model.session.isTraceEnabled
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class BuilderConfigTests {
+
+    @Test
+    fun testBuilderOutputs() {
+        val cloudworksDefaults = cloudworks().config()
+        Assert.assertTrue(cloudworksDefaults.isCloudworksActive())
+        Assert.assertTrue(cloudworksDefaults.isTraceEnabled())
+        Assert.assertFalse(cloudworksDefaults.isComprehensiveImageSubmissionEnabled())
+
+        Assert.assertFalse(cloudworks().setCloudworksTraceEnabled(false).config().isTraceEnabled())
+        Assert.assertTrue(cloudworks().setCloudworksTraceEnabled(true).config().isTraceEnabled())
+
+        Assert.assertFalse(cloudworks().setSubmitAllImagesToCloudworks(false).config().isComprehensiveImageSubmissionEnabled())
+        Assert.assertTrue(cloudworks().setSubmitAllImagesToCloudworks(true).config().isComprehensiveImageSubmissionEnabled())
+    }
+
+    fun cloudworks(): RdtProvisioningIntentBuilder {
+        return RdtIntentBuilder.forProvisioning().requestTestProfile("test").setCloudworksBackend("test")
+    }
+
+    fun RdtProvisioningIntentBuilder.config() : TestSession.Configuration {
+        return BundleToConfiguration().map(
+                this.build().getBundleExtra(INTENT_EXTRA_RDT_CONFIG_BUNDLE)!!)
+    }
+}

--- a/app/src/androidTest/java/org/rdtoolkit/MigrationTest.kt
+++ b/app/src/androidTest/java/org/rdtoolkit/MigrationTest.kt
@@ -9,6 +9,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.rdtoolkit.model.session.MIGRATION_1_2
+import org.rdtoolkit.model.session.MIGRATION_2_3
 import org.rdtoolkit.model.session.RdtDatabase
 import java.io.IOException
 
@@ -18,7 +19,7 @@ class MigrationTest {
 
     // Array of all migrations
     private val ALL_MIGRATIONS = arrayOf(
-            MIGRATION_1_2)
+            MIGRATION_1_2, MIGRATION_2_3)
 
     @get:Rule
     val helper: MigrationTestHelper = MigrationTestHelper(
@@ -50,6 +51,21 @@ class MigrationTest {
         // but you need to validate that the data was migrated properly.
     }
 
+    @Test
+    @Throws(IOException::class)
+    fun migrate2To3() {
+        var db = helper.createDatabase(TEST_DB, 2).apply {
+            // Prepare for the next version.
+            close()
+        }
+
+        // Re-open the database with version 2 and provide
+        // MIGRATION_1_2 as the migration process.
+        db = helper.runMigrationsAndValidate(TEST_DB, 3, true, MIGRATION_2_3)
+
+        // MigrationTestHelper automatically verifies the schema changes,
+        // but you need to validate that the data was migrated properly.
+    }
 
     @Test
     @Throws(IOException::class)

--- a/app/src/main/java/org/rdtoolkit/MainActivity.java
+++ b/app/src/main/java/org/rdtoolkit/MainActivity.java
@@ -23,7 +23,6 @@ import org.rdtoolkit.support.model.session.TestSession;
 
 import java.util.UUID;
 
-import static org.rdtoolkit.component.capture.WindowCaptureComponentKt.COMPONENT_WINDOWED_CAPTURE;
 import static org.rdtoolkit.support.interop.RdtIntentBuilder.ACTION_TEST_CAPTURE;
 import static org.rdtoolkit.support.interop.RdtIntentBuilder.INTENT_EXTRA_RDT_SESSION_ID;
 

--- a/app/src/main/java/org/rdtoolkit/MainActivity.java
+++ b/app/src/main/java/org/rdtoolkit/MainActivity.java
@@ -81,6 +81,7 @@ public class MainActivity extends LocaleAwareCompatActivity {
                 //.setClassifierBehavior(ClassifierMode.CHECK_YOUR_WORK)
                 .setInTestQaMode()
                 //.setSecondaryCaptureRequirements("capture_windowed")
+                //.setSubmitAllImagesToCloudworks(true)
                 .build();
 
         this.startActivityForResult(i, ACTIVITY_PROVISION);

--- a/app/src/main/java/org/rdtoolkit/interop/JsonObjectMappings.kt
+++ b/app/src/main/java/org/rdtoolkit/interop/JsonObjectMappings.kt
@@ -3,6 +3,7 @@ package org.rdtoolkit.interop
 import org.json.JSONObject
 import org.rdtoolkit.support.model.Mapper
 import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.TestSessionTraceEvent
 import org.rdtoolkit.util.getIsoUTCTimestamp
 
 
@@ -117,3 +118,22 @@ class SessionToJson(val stripSensitive : Boolean = false) : Mapper<TestSession, 
     }
 }
 
+
+class TraceToJson() : Mapper<TestSessionTraceEvent, JSONObject> {
+    override fun map(input: TestSessionTraceEvent): JSONObject {
+        val root = JSONObject()
+
+        root.put("timestamp", input.timestamp)
+        root.put("tag", input.eventTag)
+        root.put("message", input.eventMessage)
+        input.eventJson?.let {
+            root.put("json", JSONObject(it))
+
+        }
+        input.sandboxObjectId?.let {
+            root.put("media_key", it)
+
+        }
+        return root
+    }
+}

--- a/app/src/main/java/org/rdtoolkit/model/session/DbEntities.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/DbEntities.kt
@@ -1,5 +1,6 @@
 package org.rdtoolkit.model.session
 
+import androidx.annotation.NonNull
 import androidx.room.*
 import org.rdtoolkit.support.model.session.*
 import java.util.*
@@ -51,12 +52,17 @@ data class DbTestSessionMetrics (
         val data: MutableMap<String, String>
 )
 
-@Entity
+@Entity(indices = [
+    Index(name = "sessionId_index", value = ["sessionId"])
+])
 /**
  * Discrete, loggable events for forensics and monitoring of test sessions
  */
 data class DbTestSessionTraceEvent (
-        @PrimaryKey val sessionId: String,
+        @PrimaryKey(autoGenerate = true)
+        val id : Int,
+        @NonNull
+        val sessionId: String,
         val timestamp : String,
         val eventTag : String,
         val eventMessage : String,

--- a/app/src/main/java/org/rdtoolkit/model/session/Mapping.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Mapping.kt
@@ -2,6 +2,7 @@ package org.rdtoolkit.model.session
 
 import org.rdtoolkit.support.model.Mapper
 import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.TestSessionTraceEvent
 
 class SessionToDataMapper() : Mapper<TestSession, DataTestSession> {
     override fun map(input: TestSession): DataTestSession {
@@ -65,5 +66,19 @@ class DataToMetricsMapper() : Mapper<DbTestSessionMetrics?, TestSession.Metrics>
             return TestSession.Metrics(HashMap())
         }
         return TestSession.Metrics(input.data)
+    }
+}
+
+
+class TraceToDataMapper() : Mapper<TestSessionTraceEvent, DbTestSessionTraceEvent> {
+    override fun map(input: TestSessionTraceEvent): DbTestSessionTraceEvent {
+        return DbTestSessionTraceEvent(0, input.sessionId, input.timestamp, input.eventTag, input.eventMessage, input.eventJson, input.sandboxObjectId)
+
+    }
+}
+
+class DataToTraceMapper() : Mapper<DbTestSessionTraceEvent, TestSessionTraceEvent> {
+    override fun map(input : DbTestSessionTraceEvent): TestSessionTraceEvent {
+        return TestSessionTraceEvent(input.sessionId, input.timestamp, input.eventTag, input.eventMessage, input.eventJson, input.sandboxObjectId)
     }
 }

--- a/app/src/main/java/org/rdtoolkit/model/session/Migrations.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Migrations.kt
@@ -12,3 +12,14 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
                 "PRIMARY KEY(`sessionId`))")
     }
 }
+
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("DROP TABLE `DbTestSessionTraceEvent`")
+        database.execSQL("CREATE TABLE IF NOT EXISTS `DbTestSessionTraceEvent` " +
+                "(`id` INTEGER primary key autoincrement NOT NULL," +
+                "`sessionId` TEXT NOT NULL, `timestamp` TEXT NOT NULL, `eventTag` TEXT NOT NULL, " +
+                "`eventMessage` TEXT NOT NULL, `eventJson` TEXT, `sandboxObjectId` TEXT)")
+        database.execSQL("CREATE INDEX `sessionId_index` ON `DbTestSessionTraceEvent`(`sessionId`)")
+    }
+}

--- a/app/src/main/java/org/rdtoolkit/model/session/Room.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/Room.kt
@@ -77,10 +77,19 @@ interface TestSessionDao {
 
     @Query("SELECT * FROM DbTestSession ORDER BY timeStarted DESC")
     fun loadSessions(): List<DataTestSession>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun saveTrace(event: DbTestSessionTraceEvent)
+
+    @Query("SELECT * FROM DbTestSessionTraceEvent WHERE sessionId = :sessionId")
+    fun loadSessionTraces(sessionId : String) : List<DbTestSessionTraceEvent>
+
+    @Query("DELETE FROM DbTestSessionTraceEvent WHERE sessionId = :sessionId")
+    fun clearSessionTraces(sessionId: String): Int
 }
 
 @Database(entities = [DbTestSession::class, DbTestSessionConfiguration::class,
-    DbTestSessionResult::class, DbTestSessionMetrics::class, DbTestSessionTraceEvent::class], version = 2)
+    DbTestSessionResult::class, DbTestSessionMetrics::class, DbTestSessionTraceEvent::class], version = 3)
 @TypeConverters(Converters::class)
 abstract class RdtDatabase : RoomDatabase() {
     abstract fun testSessionDao(): TestSessionDao
@@ -94,7 +103,7 @@ fun getDatabase(context: Context): RdtDatabase {
             INSTANCE = Room.databaseBuilder(context.applicationContext,
                     RdtDatabase::class.java,
                     "rdtdatabase")
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2,MIGRATION_2_3)
                     .build()
         }
     }

--- a/app/src/main/java/org/rdtoolkit/model/session/SessionRepository.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/SessionRepository.kt
@@ -1,7 +1,7 @@
 package org.rdtoolkit.model.session
 
-import org.rdtoolkit.support.model.ListMapperImpl
 import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.TestSessionTraceEvent
 
 interface SessionRepository {
     fun write(testSession: TestSession)
@@ -13,4 +13,10 @@ interface SessionRepository {
     fun loadSessions(): List<TestSession>
 
     fun clearSession(sessionId: String) : Boolean
+
+    fun recordTraceEvent(event: TestSessionTraceEvent)
+
+    fun loadTraceEvents(sessionId : String) : List<TestSessionTraceEvent>
+
+    fun clearTraceEvents(sessionId : String)
 }

--- a/app/src/main/java/org/rdtoolkit/model/session/SessionRepositoryImpl.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/SessionRepositoryImpl.kt
@@ -4,6 +4,7 @@ import org.rdtoolkit.processing.WorkCoordinator
 import org.rdtoolkit.support.model.ListMapperImpl
 import org.rdtoolkit.support.model.session.STATUS
 import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.TestSessionTraceEvent
 import java.lang.Exception
 
 class SessionRepositoryImpl(private var testSessionDao : TestSessionDao,
@@ -38,4 +39,16 @@ class SessionRepositoryImpl(private var testSessionDao : TestSessionDao,
         return testSessionDao.delete(sessionId) > 0
     }
 
+    override fun recordTraceEvent(event: TestSessionTraceEvent) {
+        testSessionDao.saveTrace(TraceToDataMapper().map(event))
+
+    }
+
+    override fun loadTraceEvents(sessionId : String) : List<TestSessionTraceEvent> {
+        return ListMapperImpl(DataToTraceMapper()).map(testSessionDao.loadSessionTraces(sessionId))
+    }
+
+    override fun clearTraceEvents(sessionId : String) {
+        testSessionDao.clearSessionTraces(sessionId)
+    }
 }

--- a/app/src/main/java/org/rdtoolkit/model/session/TraceReporter.kt
+++ b/app/src/main/java/org/rdtoolkit/model/session/TraceReporter.kt
@@ -1,0 +1,36 @@
+package org.rdtoolkit.model.session
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.json.JSONException
+import org.json.JSONObject
+import org.rdtoolkit.support.model.session.TestSessionTraceEvent
+import org.rdtoolkit.util.getIsoUTCTimestamp
+import java.util.*
+
+class TraceReporter(val repo : SessionRepository, val scope : CoroutineScope) {
+    private lateinit var sessionId : String
+
+    fun trace(tag : String, message : String, eventJson : String? = null, sandboxObjectId : String? = null) {
+        if (!this::sessionId.isInitialized) {
+            //TODO : queue preinit traces?
+            return;
+        }
+
+        //TODO: Ideally we'd have a single dispatcher for logging which can ensure that requests are
+        //processed FIFO
+        scope.launch(Dispatchers.IO) {
+            eventJson?.apply {
+                //if a json payload was provided, ensure that it is well formed
+                JSONObject(eventJson)
+            }
+
+            repo.recordTraceEvent(TestSessionTraceEvent(sessionId, getIsoUTCTimestamp(Date())!!, tag, message, eventJson, sandboxObjectId))
+        }
+    }
+
+    fun enableTraceRecording(sessionId : String) {
+        this.sessionId = sessionId
+    }
+}

--- a/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
+++ b/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
@@ -1,6 +1,7 @@
 package org.rdtoolkit.processing
 
 import android.content.Context
+import okhttp3.Dispatcher
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -29,6 +30,7 @@ class CloudworksApi(dns: String, val sessionId : String, val context : Context) 
     private val client = OkHttpClient.Builder()
             .readTimeout(CONNECTION_READ_TIMEOUT.toLong(), TimeUnit.SECONDS)
             .writeTimeout(CONNECTION_WRITE_TIMEOUT.toLong(), TimeUnit.SECONDS)
+            .dispatcher(Dispatcher().also { it.maxRequestsPerHost = 2 })
             .build()
 
     fun submitSessionJson(session: TestSession) {
@@ -60,8 +62,10 @@ class CloudworksApi(dns: String, val sessionId : String, val context : Context) 
 
         val response = client.newCall(sessionBodyRequest).execute()
 
-        if (!(response.code == 201 || response.code == 200 || response.code == 409)) {
-            throw Exception("Invalid server response ${response.code} with body ${response.body?.string()}")
+        response.use { response ->
+            if (!(response.code == 201 || response.code == 200 || response.code == 409)) {
+                throw Exception("Invalid server response ${response.code} with body ${response.body?.string()}")
+            }
         }
     }
 
@@ -73,8 +77,10 @@ class CloudworksApi(dns: String, val sessionId : String, val context : Context) 
 
         val response = client.newCall(sessionBodyRequest).execute()
 
-        if (!(response.code == 201 || response.code == 200 || response.code == 409)) {
-            throw Exception("Invalid server response ${response.code} with body ${response.body?.string()}")
+        response.use { response ->
+            if (!(response.code == 201 || response.code == 200 || response.code == 409)) {
+                throw Exception("Invalid server response ${response.code} with body ${response.body?.string()}")
+            }
         }
     }
 

--- a/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
+++ b/app/src/main/java/org/rdtoolkit/processing/CloudworksApi.kt
@@ -7,8 +7,13 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONArray
+import org.json.JSONObject
 import org.rdtoolkit.interop.SessionToJson
+import org.rdtoolkit.interop.TraceToJson
+import org.rdtoolkit.support.model.ListMapperImpl
 import org.rdtoolkit.support.model.session.TestSession
+import org.rdtoolkit.support.model.session.TestSessionTraceEvent
 import java.io.File
 import java.util.concurrent.TimeUnit
 
@@ -31,6 +36,16 @@ class CloudworksApi(dns: String, val sessionId : String, val context : Context) 
         val body = json.toString(4).toRequestBody(JSON)
 
         put(getSessionSubmissionEndpoint(), body)
+    }
+
+    fun submitTraceJson(traces : List<TestSessionTraceEvent>) {
+        val envelope = JSONObject()
+        envelope.put("entries", JSONArray(ListMapperImpl(TraceToJson()).map(traces)))
+        val text = envelope.toString(4)
+
+        val body = text.toRequestBody(JSON)
+
+        put(getSessionTraceEndpoint(), body)
     }
 
     fun submitSessionMedia(key: String, file: File) {
@@ -65,6 +80,9 @@ class CloudworksApi(dns: String, val sessionId : String, val context : Context) 
 
     private fun getSessionSubmissionEndpoint() : String {
         return "$dns/test_session/$sessionId/"
+    }
+    private fun getSessionTraceEndpoint() : String {
+        return "$dns/test_session/$sessionId/logs/"
     }
 
     private fun getSessionMediaSubmissionEndpoint(key : String) : String {

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
@@ -56,19 +56,9 @@ public class CaptureActivity extends LocaleAwareCompatActivity {
     CaptureViewModel captureViewModel;
     PamphletViewModel pamphletViewModel;
 
-    ComponentManager componentManager = new ComponentManager(this, new ComponentEventListener() {
-        @Override
-        public void testImageCaptured(@NotNull ImageCaptureResult imageResult) {
-            CaptureActivity.this.testImageCaptured(imageResult);
-        }
-    }, 100);
+    ComponentManager componentManager;
 
-    ComponentManager secondaryComponentManager = new ComponentManager(this, new ComponentEventListener() {
-        @Override
-        public void testImageCaptured(@NotNull ImageCaptureResult imageResult) {
-            CaptureActivity.this.secondaryImageCaptured(imageResult);
-        }
-    }, 200);
+    ComponentManager secondaryComponentManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -88,6 +78,20 @@ public class CaptureActivity extends LocaleAwareCompatActivity {
                 new ViewModelProvider(this,
                         InjectorUtils.Companion.providePamphletViewModelFactory(this))
                         .get(PamphletViewModel.class);
+
+        componentManager  = new ComponentManager(this, new ComponentEventListener() {
+            @Override
+            public void testImageCaptured(@NotNull ImageCaptureResult imageResult) {
+                CaptureActivity.this.testImageCaptured(imageResult);
+            }
+        }, captureViewModel.getReporter(), 100);
+
+        secondaryComponentManager = new ComponentManager(this, new ComponentEventListener() {
+            @Override
+            public void testImageCaptured(@NotNull ImageCaptureResult imageResult) {
+                CaptureActivity.this.secondaryImageCaptured(imageResult);
+            }
+        }, captureViewModel.getReporter(), 200);
 
         // Passing each menu ID as a set of Ids because each
         // menu should be considered as top level destinations.

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureViewModel.kt
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureViewModel.kt
@@ -10,6 +10,7 @@ import org.rdtoolkit.model.diagnostics.Pamphlet
 import org.rdtoolkit.model.diagnostics.RdtDiagnosticProfile
 import org.rdtoolkit.model.session.AppRepository
 import org.rdtoolkit.model.session.SessionRepository
+import org.rdtoolkit.model.session.TraceReporter
 import org.rdtoolkit.support.model.session.*
 import org.rdtoolkit.util.CombinedLiveData
 import java.util.*
@@ -21,6 +22,8 @@ class CaptureViewModel(var sessionRepository: SessionRepository,
                        var diagnosticsRepository: DiagnosticsRepository,
                        var appRepository: AppRepository
 ) : ViewModel() {
+
+    val reporter = TraceReporter(sessionRepository, viewModelScope)
 
     private val testSession : MutableLiveData<TestSession> = MutableLiveData()
     private val testState : MutableLiveData<TestReadableState> = MutableLiveData()
@@ -289,6 +292,10 @@ class CaptureViewModel(var sessionRepository: SessionRepository,
                 sessionIsInvalid.postValue(true)
             } else {
                 val session = sessionRepository.getTestSession(sessionId)
+
+                if(session.configuration.cloudworksDns != null) {
+                    reporter.enableTraceRecording(sessionId)
+                }
 
                 testSession.postValue(session)
 

--- a/app/src/restricted/java/org/rdtoolkit/component/scanwell/DiatomicProcessor.kt
+++ b/app/src/restricted/java/org/rdtoolkit/component/scanwell/DiatomicProcessor.kt
@@ -92,8 +92,7 @@ class DiatomicProcessor(private val context : Context, private val config : Diat
         decoder.inPreferredConfig = Bitmap.Config.ARGB_8888;
 
         val image = BitmapFactory.decodeFile(reticleResult.rawImagePath, decoder)
-        Log.i(LOG_TAG, "Initializing ${image.height} x ${image.width} reader for test ${config.rdt}");
-
+        Log.i(LOG_TAG, "Initializing ${image.height} x ${image.width} reader for test ${config.rdt}")
 
         RDTReader.init(context, config.rdt, image.height, image.width)
 
@@ -101,7 +100,10 @@ class DiatomicProcessor(private val context : Context, private val config : Diat
         if (result.errorCode == null || result.resultCode == null) {
             throw Exception("Invalid Result Data from Scanner")
         }
-        Log.i(LOG_TAG, String.format("RDTReader::findRdt(): %s(%d) Result %s(%d)", result.errorCode, result.errorCode.code, result.resultCode, result.resultCode.code));
+        val msg = String.format("RDTReader::findRdt(): %s(%d) Result %s(%d)", result.errorCode, result.errorCode.code, result.resultCode, result.resultCode.code)
+        Log.i(LOG_TAG, msg);
+
+        reporter!!.trace(LOG_TAG, msg, result.metadata)
 
         if (result.errorCode == RDTReader.ErrorCode.SUCCESS) {
             listener.onClassifierComplete(config.getResultsMap(result.resultCode))

--- a/app/src/restricted/java/org/rdtoolkit/component/scanwell/DiatomicProcessor.kt
+++ b/app/src/restricted/java/org/rdtoolkit/component/scanwell/DiatomicProcessor.kt
@@ -103,7 +103,7 @@ class DiatomicProcessor(private val context : Context, private val config : Diat
         val msg = String.format("RDTReader::findRdt(): %s(%d) Result %s(%d)", result.errorCode, result.errorCode.code, result.resultCode, result.resultCode.code)
         Log.i(LOG_TAG, msg);
 
-        reporter!!.trace(LOG_TAG, msg, result.metadata)
+        reporter!!.trace(LOG_TAG, msg, result.metadata, reticleResult.rawImagePath)
 
         if (result.errorCode == RDTReader.ErrorCode.SUCCESS) {
             listener.onClassifierComplete(config.getResultsMap(result.resultCode))

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/interop/RdtIntentBuilder.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/interop/RdtIntentBuilder.kt
@@ -163,6 +163,16 @@ class RdtProvisioningIntentBuilder() : RdtIntentBuilder<RdtProvisioningIntentBui
         return this
     }
 
+    fun setSubmitAllImagesToCloudworks(captureAll : Boolean) : RdtProvisioningIntentBuilder {
+        configBundle.getBundle(INTENT_EXTRA_RDT_CONFIG_FLAGS)!!.putString(FLAG_SESSION_CLOUDWORKS_FULL_IMAGE_SUBMISSION, if (captureAll) FLAG_VALUE_SET else FLAG_VALUE_UNSET)
+        return this
+    }
+
+    fun setCloudworksTraceEnabled(traceEnabled : Boolean) : RdtProvisioningIntentBuilder {
+        configBundle.getBundle(INTENT_EXTRA_RDT_CONFIG_FLAGS)!!.putString(FLAG_SESSION_CLOUDWORKS_CAPTURE_TRACE, if (traceEnabled) FLAG_VALUE_SET else FLAG_VALUE_UNSET)
+        return this
+    }
+
     /**
      * Configure the test session in a testing / qa mode which will allow for overriding certain
      * actions for smoothness

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/DomainModels.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/DomainModels.kt
@@ -52,6 +52,15 @@ data class TestSession (
     )
 }
 
+data class TestSessionTraceEvent (
+        val sessionId: String,
+        val timestamp : String,
+        val eventTag : String,
+        val eventMessage : String,
+        val eventJson : String? = null,
+        val sandboxObjectId: String? = null
+)
+
 enum class TestReadableState {
     LOADING,
     PREPARING,

--- a/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/SessionFlags.kt
+++ b/rd-toolkit-support/src/main/java/org/rdtoolkit/support/model/session/SessionFlags.kt
@@ -11,14 +11,37 @@ const val FLAG_CALLING_PACKAGE = "FLAG_ANDROID_CALLING_PACKAGE"
 const val FLAG_VALUE_SET = "TRUE"
 const val FLAG_VALUE_UNSET = "FALSE"
 
+const val FLAG_SESSION_CLOUDWORKS_CAPTURE_TRACE= "FLAG_CLOUDWORKS_CAPTURE_TRACE"
+const val FLAG_SESSION_CLOUDWORKS_FULL_IMAGE_SUBMISSION= "FLAG_SESSION_CLOUDWORKS_FULL_IMAGE_SUBMISSION"
+
 const val FLAG_SECONDARY_CAPTURE = "FLAG_CAPTURE_SECONDARY_INPUT"
 const val FLAG_SECONDARY_PARAMS = "FLAG_CAPTURE_SECONDARY_PARAMS"
 
 const val FLAG_CAPTURE_PARAMS = "FLAG_CAPTURE_PARAMS"
 const val FLAG_CAPTURE_REQUIREMENTS = "FLAG_CAPTURE_REQUIREMENTS"
 
+fun TestSession.Configuration.isCloudworksActive() : Boolean {
+    return this.cloudworksDns != null
+}
+
+fun TestSession.Configuration.isTraceEnabled() : Boolean {
+    return this.isCloudworksActive() && isFlagSet(FLAG_SESSION_CLOUDWORKS_CAPTURE_TRACE, true)
+}
+
+fun TestSession.Configuration.isComprehensiveImageSubmissionEnabled() : Boolean {
+    return this.isCloudworksActive() && isFlagSet(FLAG_SESSION_CLOUDWORKS_FULL_IMAGE_SUBMISSION)
+}
+
+fun TestSession.Configuration.isFlagSet(flag : String, default : Boolean = false) : Boolean {
+    return if (default)  {
+        FLAG_VALUE_UNSET != this.flags[flag]
+    } else {
+        FLAG_VALUE_SET == this.flags[flag]
+    }
+}
+
 fun TestSession.Configuration.wasSecondaryCaptureRequested() : Boolean {
-    return this.flags[FLAG_SECONDARY_CAPTURE] == FLAG_VALUE_SET
+    return isFlagSet(FLAG_SECONDARY_CAPTURE)
 }
 
 fun TestSession.Configuration.getSecondaryCaptureParams() : Map<String, String> {


### PR DESCRIPTION
Introduces session Trace Logs which can capture event level data that occurs during a test capture session, and implements detailed classifier reporting with the full metadata output. Trace capture is enabled by default for reportable (cloudworks) sessions, but can be disabled manually.

Also introduces a flaggable "verbose" capture mode for test sessions which will retain and submit all images captured. 

Finally, adds some tuning for API submission network behavior which limits the number of simultaneous connections, to make better use of limited bandwidth. A capture session can now result in at least 6 pieces of media to be submitted, so it would be easy to accidentally flood and saturate a high / bursty latency connection and never get anything off the device.