### PR TITLE
Configure media permissions for Android 11+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,7 +104,7 @@ dependencies {
 
     def nav_version = "2.3.1"
     def lifecycle_version = "2.2.0"
-    def camerax_version = "1.0.0-rc03"
+    def camerax_version = "1.0.0-rc04"
 
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/app/src/androidTest/java/org/rdtoolkit/IntentSerializationTest.java
+++ b/app/src/androidTest/java/org/rdtoolkit/IntentSerializationTest.java
@@ -53,6 +53,18 @@ public class IntentSerializationTest {
         testRoundTrip(Constants.SessionCompleted);
     }
 
+    @Test
+    public void testFilePathTransforms() {
+        TestSession.TestResult roundTripResult = new BundleToResult().map(new ResultToBundle(new ReversingStringMapper()).map(Constants.TestResultsSampleValues));
+        Assert.assertEquals("htaptset", roundTripResult.getMainImage());
+        Assert.assertEquals("htaptset", roundTripResult.getImages().get("raw"));
+
+        TestSession roundTripSession = new BundleToSession().map(new SessionToBundle(new ReversingStringMapper()).map(Constants.SessionCompleted));
+        Assert.assertEquals("htaptset", roundTripSession.getResult().getMainImage());
+        Assert.assertEquals("htaptset", roundTripSession.getResult().getImages().get("raw"));
+    }
+
+
     private <T> void testRoundTrip(T t) {
         Pair<Mapper<Object, Intent>, Mapper<Intent,Object>> pair = serializers.get(t.getClass());
         Assert.assertEquals(t, pair.second.map(pair.first.map((Object)t)));

--- a/app/src/androidTest/java/org/rdtoolkit/MappingTests.java
+++ b/app/src/androidTest/java/org/rdtoolkit/MappingTests.java
@@ -11,10 +11,12 @@ import org.junit.runner.RunWith;
 import org.rdtoolkit.support.interop.BundleToStringMap;
 import org.rdtoolkit.support.interop.FixedSetKeyQualifier;
 import org.rdtoolkit.support.interop.PrefixKeyQualifier;
+import org.rdtoolkit.support.interop.StringIdentityMapper;
 import org.rdtoolkit.support.interop.StringMapToBundle;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,6 +51,12 @@ public class MappingTests {
         for (String key : map.keySet()) {
             Assert.assertEquals(map.get(key), b.getString(key));
         }
+    }
+
+    @Test
+    public void testIdentityMapper() {
+        StringIdentityMapper m = new StringIdentityMapper();
+        Assert.assertEquals("value",m.map("value"));
     }
 
     @Test

--- a/app/src/androidTest/java/org/rdtoolkit/TestObjects.kt
+++ b/app/src/androidTest/java/org/rdtoolkit/TestObjects.kt
@@ -1,5 +1,6 @@
 package org.rdtoolkit
 
+import org.rdtoolkit.support.model.Mapper
 import org.rdtoolkit.support.model.session.*
 import java.util.*
 import kotlin.collections.HashMap
@@ -40,4 +41,10 @@ object Constants {
             Date(Date().time - 250),
             TestResultsSampleValues,
             TestSession.Metrics(HashMap()))
+}
+
+class ReversingStringMapper : Mapper<String?, String?> {
+    override fun map(input: String?): String? {
+        return input?.reversed()
+    }
 }

--- a/app/src/androidTest/java/org/rdtoolkit/XFormResultTranslatorTest.java
+++ b/app/src/androidTest/java/org/rdtoolkit/XFormResultTranslatorTest.java
@@ -9,6 +9,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.rdtoolkit.interop.InterfacesKt;
+import org.rdtoolkit.interop.StringIdentityMapper;
 import org.rdtoolkit.interop.translator.InteropRepository;
 
 import java.util.Map;
@@ -52,7 +53,7 @@ public class XFormResultTranslatorTest {
 
     @Test
     public void testWithSession() {
-        Intent sessionIntent = InterfacesKt.captureReturnIntent(Constants.SessionCompleted);
+        Intent sessionIntent = InterfacesKt.captureReturnIntent(Constants.SessionCompleted, new StringIdentityMapper());
         Intent output = new InteropRepository().getTranslator(TRANSLATOR_XFORM_RESULT).map(sessionIntent);
         Bundle xformBundle = output.getBundleExtra("odk_intent_bundle");
 

--- a/app/src/main/java/org/rdtoolkit/component/capture/WindowCaptureActivity.kt
+++ b/app/src/main/java/org/rdtoolkit/component/capture/WindowCaptureActivity.kt
@@ -5,16 +5,13 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.*
 import android.graphics.drawable.ColorDrawable
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
-import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.util.Log
@@ -23,7 +20,6 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.camera2.interop.Camera2CameraInfo
 import androidx.camera.core.*
@@ -33,7 +29,6 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import kotlinx.android.synthetic.main.activity_window_capture.*
 import org.rdtoolkit.R
 import java.io.File
@@ -188,7 +183,6 @@ class WindowCaptureActivity : AppCompatActivity() {
                     .also {
                             it.setSurfaceProvider(capture_window_camera_preview.surfaceProvider)
                     }
-
 
             imageCapture = ImageCapture.Builder()
                     .setCaptureMode(ImageCapture.CAPTURE_MODE_MAXIMIZE_QUALITY)

--- a/app/src/main/java/org/rdtoolkit/interop/DispatcherActivity.java
+++ b/app/src/main/java/org/rdtoolkit/interop/DispatcherActivity.java
@@ -1,6 +1,7 @@
 package org.rdtoolkit.interop;
 
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -51,8 +52,18 @@ public class DispatcherActivity extends AppCompatActivity {
             this.finish();
         }
         if(requestCode == ACTIVITY_RESULT_PASSTHROUGH && resultCode == RESULT_OK) {
-            this.setResult(resultCode, interopRepo.translateResponse(data));
+            Intent responseIntent = interopRepo.translateResponse(data).setData(data.getData());
+            copyInternals(responseIntent, data);
+            responseIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+            this.setResult(resultCode, responseIntent);
             this.finish();
+        }
+    }
+
+
+    private void copyInternals(Intent destination, Intent source) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            destination.setClipData(source.getClipData());
         }
     }
 }

--- a/app/src/main/java/org/rdtoolkit/interop/Interfaces.kt
+++ b/app/src/main/java/org/rdtoolkit/interop/Interfaces.kt
@@ -1,8 +1,13 @@
 package org.rdtoolkit.interop
 
+import android.content.ClipData
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.core.content.FileProvider
 import org.rdtoolkit.interop.translator.InteropRepository
+import org.rdtoolkit.support.interop.FilePathMapper
 import org.rdtoolkit.support.interop.RdtIntentBuilder.Companion.INTENT_EXTRA_INPUT_TRANSLATOR
 import org.rdtoolkit.support.interop.RdtIntentBuilder.Companion.INTENT_EXTRA_RDT_CONFIG_BUNDLE
 import org.rdtoolkit.support.interop.RdtIntentBuilder.Companion.INTENT_EXTRA_RDT_SESSION_BUNDLE
@@ -10,6 +15,8 @@ import org.rdtoolkit.support.interop.RdtIntentBuilder.Companion.INTENT_EXTRA_RDT
 import org.rdtoolkit.support.interop.SessionToBundle
 import org.rdtoolkit.support.model.session.TestSession
 import org.rdtoolkit.ui.provision.ProvisionActivity
+import java.io.File
+
 
 fun provisionIntent(context : Context, incoming: Intent) : Intent {
     var toBootstrap = incoming
@@ -40,9 +47,46 @@ fun provisionReturnIntent(session : TestSession) : Intent {
     return intent
 }
 
-fun captureReturnIntent(session : TestSession) : Intent {
+fun captureReturnIntent(session : TestSession, filePathWrapper : FilePathMapper) : Intent {
     val intent = Intent()
     intent.putExtra(INTENT_EXTRA_RDT_SESSION_ID, session.sessionId)
-    intent.putExtra(INTENT_EXTRA_RDT_SESSION_BUNDLE, SessionToBundle().map(session))
+    intent.putExtra(INTENT_EXTRA_RDT_SESSION_BUNDLE, SessionToBundle(filePathWrapper).map(session))
+
+    filePathWrapper.prepare(intent)
+
     return intent
+}
+
+fun getFileEncodingMapper(context : Context, useUriByDefault : Boolean = false) : FilePathMapper {
+    val useUri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || useUriByDefault
+    if (useUri) {
+        return FileUriResponseMapper(context)
+    } else {
+        return FilePathMapper()
+    }
+}
+
+class FileUriResponseMapper(val context : Context) : FilePathMapper() {
+    override fun map(input: String?): String? {
+        val fileUri: Uri? = input?.let {
+            FileProvider.getUriForFile(
+                    context,
+                    "org.rdtoolkit.fileprovider",
+                    File(input))
+        }
+
+        return fileUri?.toString().also { it?.let { this.outputs.add(it) } }
+    }
+
+    override fun prepare(intent: Intent) {
+        if (outputs.isNotEmpty()) {
+            val i = outputs.iterator()
+            val clipData = ClipData.newRawUri(null, Uri.parse(i.next()))
+            while (i.hasNext()) {
+                clipData.addItem(ClipData.Item(Uri.parse(i.next())))
+            }
+
+            intent.clipData = clipData
+        }
+    }
 }

--- a/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
+++ b/app/src/main/java/org/rdtoolkit/ui/capture/CaptureActivity.java
@@ -31,6 +31,7 @@ import org.rdtoolkit.component.ImageClassifierComponent;
 import org.rdtoolkit.component.ProcessingListener;
 import org.rdtoolkit.component.Sandbox;
 import org.rdtoolkit.component.TestImageCaptureComponent;
+import org.rdtoolkit.interop.FileUriResponseMapper;
 import org.rdtoolkit.model.diagnostics.Pamphlet;
 import org.rdtoolkit.model.diagnostics.RdtDiagnosticProfile;
 import org.rdtoolkit.support.model.session.STATUS;
@@ -46,6 +47,7 @@ import java.util.Map;
 import kotlin.NotImplementedError;
 
 import static org.rdtoolkit.interop.InterfacesKt.captureReturnIntent;
+import static org.rdtoolkit.interop.InterfacesKt.getFileEncodingMapper;
 import static org.rdtoolkit.support.interop.RdtIntentBuilder.INTENT_EXTRA_RDT_SESSION_ID;
 import static org.rdtoolkit.support.interop.RdtIntentBuilder.INTENT_EXTRA_RESPONSE_TRANSLATOR;
 import static org.rdtoolkit.support.model.session.MetricsKt.setDeviceMetadata;
@@ -368,7 +370,7 @@ public class CaptureActivity extends LocaleAwareCompatActivity {
     }
 
     private void finishSession(TestSession session) {
-        Intent returnIntent = captureReturnIntent(session);
+        Intent returnIntent = captureReturnIntent(session, getFileEncodingMapper(this, false));
         if (session.getConfiguration().getOutputResultTranslatorId() != null) {
             returnIntent.putExtra(INTENT_EXTRA_RESPONSE_TRANSLATOR,
                     session.getConfiguration().getOutputResultTranslatorId());

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 


### PR DESCRIPTION
Issue Link: https://github.com/dimagi/rd-toolkit/issues/37

For Android 11+ platforms performs an in-place translation for all file paths into content provider URI's, and loads those URI's into clipdata with appropriate permissions for response.

Necessary to allow IPC permissions for media file transfer on newest android platforms. 