### PR TITLE
Use Content URI's on Android 10+ rather than 11+

### DIFF
--- a/app/src/main/java/org/rdtoolkit/interop/Interfaces.kt
+++ b/app/src/main/java/org/rdtoolkit/interop/Interfaces.kt
@@ -58,7 +58,7 @@ fun captureReturnIntent(session : TestSession, filePathWrapper : FilePathMapper)
 }
 
 fun getFileEncodingMapper(context : Context, useUriByDefault : Boolean = false) : FilePathMapper {
-    val useUri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R || useUriByDefault
+    val useUri = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q || useUriByDefault
     if (useUri) {
         return FileUriResponseMapper(context)
     } else {


### PR DESCRIPTION
Issue: https://github.com/dimagi/rd-toolkit/issues/47

Android's new content uri permissions are technically only fully required for Android 11, but any Android 10 builds against the Android 11+ build targets also require the new permissions scheme. 

This change simply forces the app to use the content scheme on Android 10 across the board. Any legacy apps using the older scheme on Android 10 will need to update their content pulls, but that requirement will be coming for them either way later this year.