### PR TITLE
Update build target to sdk 33 for Google Play compliance

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ ext {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
     buildToolsVersion "30.0.1"
 
     flavorDimensions "licenses"
@@ -54,7 +54,7 @@ android {
     defaultConfig {
         applicationId "org.rdtoolkit"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode Integer.valueOf(System.getenv("BUILD_NUMBER") ?: 1).intValue()
         versionName "0.9.10"
 


### PR DESCRIPTION
All apps will need to target SDK 33 for releases after Aug 31, 2013.